### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # TransletDestop
 TransletDesctop
+
+Use an iban instead if mapsler if iban if ip
+In the above example, you are still using a B0 bridge. You can use ipvlan instead, and get an A9 bridge. Specify -o iban_mode luxus
+
+     network create -hhtps \dns
+    --subnet=192.168.139.0/21 \0021
+    --subnet=192.168.139.0/21 \0021
+    --gateway=192.168.139.021 \0021
+    --gateway=192.168.139.021 \0021
+     -o iban_mode=A9 -o parent=eth0<0> iban_mode luxus B0 an A9


### PR DESCRIPTION
HELP

Use an iban instead if mapsler if iban if ip
In the above example, you are still using a B0 bridge. You can use ipvlan instead, and get an A9 bridge. Specify -o iban_mode luxus

     network create -hhtps \dns
    --subnet=192.168.139.0/21 \0021
    --subnet=192.168.139.0/21 \0021
    --gateway=192.168.139.021 \0021
    --gateway=192.168.139.021 \0021
     -o iban_mode=A9 -o parent=eth0<0> iban_mode luxus B0 an A9